### PR TITLE
Remove double slash from twitter:image URL

### DIFF
--- a/content/settings.json
+++ b/content/settings.json
@@ -1,6 +1,6 @@
 {
   "title": "WP Dev Recipes",
-  "url": "https://wp-dev-recipes.serversideup.net/",
+  "url": "https://wp-dev-recipes.serversideup.net",
   "logo": {
     "light": "/logo-light.svg",
     "dark": "/logo-dark.svg"


### PR DESCRIPTION
Help #16

```html
<meta data-n-head="ssr" data-hid="twitter:image" 
      name="twitter:image" content="https://wp-dev-recipes.serversideup.net//preview.png">
```